### PR TITLE
Fixed error when no passing root

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,13 @@
 var _ = require('lodash'),
     fs = require('fs'),
     path = require('path'),
-    send = require('koa-send');
+    send = require('koa-send'),
+    debug = require('debug')('koa-serve');
 
 module.exports = exports = function (directories, root) {
     if (!_.isArray(directories)) directories = [directories];
-    root = path.normalize(root) || path.join(__dirname, '..', '..');
+    root = root || path.join(__dirname, '..', '..');
+    root = path.normalize(root);
 
     return function *(next) {
         var reqPath = this.path,
@@ -17,18 +19,19 @@ module.exports = exports = function (directories, root) {
             return _.startsWith(reqPath, '/' + dir);
         });
 
+        debug('requesting', reqPath);
+        this.path = root + this.path;
         try
         {
-            filePath = (isAsset && !fs.lstatSync(root + this.path).isDirectory())
-                ? root + this.path
-                : root + this.path + 'index.html';
+            filePath = (isAsset && !fs.lstatSync(this.path).isDirectory())
+                ? this.path
+                : this.path + 'index.html';
 
-            fd = fs.openSync(filePath, 'r');
             yield send(this, filePath);
-            fs.close(fd);
         }
         catch (e)
         {
+            debug(e);
             if (isAsset) {
                 this.body = 'Not Found';
                 this.status = 404;

--- a/index.js
+++ b/index.js
@@ -19,18 +19,19 @@ module.exports = exports = function (directories, root) {
             return _.startsWith(reqPath, '/' + dir);
         });
 
-        debug('requesting', reqPath);
+        if (!isAsset) return yield next;
+
+        debug('requested:', reqPath);
         this.path = root + this.path;
-        try
-        {
+        try {
             filePath = (isAsset && !fs.lstatSync(this.path).isDirectory())
                 ? this.path
                 : this.path + 'index.html';
 
+            debug('served:', filePath);
             yield send(this, filePath);
         }
-        catch (e)
-        {
+        catch (e) {
             debug(e);
             if (isAsset) {
                 this.body = 'Not Found';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/adamkdean/koa-serve",
   "dependencies": {
     "lodash": "^3.10.1",
+    "debug": "^2.2.0",
     "koa-send": "^1.3.1"
   }
 }


### PR DESCRIPTION
I tried to use the module following the first example in the README (without passing root) and I got this error:

```
path.js:479
  return path.charAt(0) === '/';
             ^
TypeError: Cannot read property 'charAt' of undefined
    at Object.posix.isAbsolute (path.js:479:14)
    at Object.posix.normalize (path.js:461:26)
    at module.exports.exports (/Users/satanas/proyectos/foldee/client/node_modules/koa-serve/index.js:11:17)
    at Object.<anonymous> (/Users/satanas/proyectos/foldee/client/index.js:24:9)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
```

I realized that when root is undefined, `path.normalize` throws the error above, so I adjusted the code to assign a value to root before. I also refactored some code to avoid duplications.

Plus, I implemented a debug output to help people understand what requests is being done when executing with:

`DEBUG=* node my_file.js`
