### PR TITLE
Yield properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,13 @@
 var _ = require('lodash'),
     fs = require('fs'),
     path = require('path'),
-    send = require('koa-send');
+    send = require('koa-send'),
+    debug = require('debug')('koa-serve');
 
 module.exports = exports = function (directories, root) {
     if (!_.isArray(directories)) directories = [directories];
-    root = path.normalize(root) || path.join(__dirname, '..', '..');
+    root = root || path.join(__dirname, '..', '..');
+    root = path.normalize(root);
 
     return function *(next) {
         var reqPath = this.path,
@@ -17,18 +19,19 @@ module.exports = exports = function (directories, root) {
             return _.startsWith(reqPath, '/' + dir);
         });
 
+        debug('requesting', reqPath);
+        this.path = root + this.path;
         try
         {
-            filePath = (isAsset && !fs.lstatSync(root + this.path).isDirectory())
-                ? root + this.path
-                : root + this.path + 'index.html';
+            filePath = (isAsset && !fs.lstatSync(this.path).isDirectory())
+                ? this.path
+                : this.path + 'index.html';
 
-            fd = fs.openSync(filePath, 'r');
             yield send(this, filePath);
-            fs.close(fd);
         }
         catch (e)
         {
+            debug(e);
             if (isAsset) {
                 this.body = 'Not Found';
                 this.status = 404;

--- a/index.js
+++ b/index.js
@@ -19,18 +19,19 @@ module.exports = exports = function (directories, root) {
             return _.startsWith(reqPath, '/' + dir);
         });
 
-        debug('requesting', reqPath);
+        if (!isAsset) return yield next;
+
+        debug('requested:', reqPath);
         this.path = root + this.path;
-        try
-        {
+        try {
             filePath = (isAsset && !fs.lstatSync(this.path).isDirectory())
                 ? this.path
                 : this.path + 'index.html';
 
+            debug('served:', filePath);
             yield send(this, filePath);
         }
-        catch (e)
-        {
+        catch (e) {
             debug(e);
             if (isAsset) {
                 this.body = 'Not Found';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/adamkdean/koa-serve",
   "dependencies": {
     "lodash": "^3.10.1",
+    "debug": "^2.2.0",
     "koa-send": "^1.3.1"
   }
 }


### PR DESCRIPTION
This PR makes the middleware yield properly when it's added first than any other middleware. If you consider the following example:

```
let koa = require('koa');
let _ = require('koa-route');
let serve = require('koa-serve');

let app = koa();

app.use(serve('assets'));

app.use(_.get('/', function* () {
  this.body = 'Hello world';
}));

app.listen(8000);
```

It will serve static files like http://localhost:8000/assets/css/test.css correctly but will return 'Not Found' with a 404 error if you try http://localhost:8000.

In order to avoid instructions like "Please, put this middleware at the beginning of your koa application" I've done this fix. I also improved the debug output and adjusted some curly braces for consistency.

Please, merge this PR after #1
