### PR TITLE
Fix req without directory separator ending

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = exports = function (directories, root) {
         try {
             filePath = (isAsset && !fs.lstatSync(root + this.path).isDirectory())
                 ? root + this.path
-                : root + this.path + 'index.html';
+                : path.join(root,this.path,'index.html');
 
             debug('served:', filePath);
             yield send(this, filePath);

--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@ var _ = require('lodash'),
     fs = require('fs'),
     path = require('path'),
     send = require('koa-send'),
-    debug = require('debug')('koa-serve');
+    debug = require('debug')('koa-serve'),
+    assert = require('assert');
 
 module.exports = exports = function (directories, root) {
+    assert(directories,"Directory argument not specified");
     if (!_.isArray(directories)) directories = [directories];
     root = root || path.join(__dirname, '..', '..');
     root = path.normalize(root);

--- a/index.js
+++ b/index.js
@@ -25,10 +25,12 @@ module.exports = exports = function (directories, root) {
 
         debug('requested:', reqPath);
         try {
-            filePath = (isAsset && !fs.lstatSync(root + this.path).isDirectory())
+            var isDir = fs.lstatSync(root + this.path).isDirectory();
+            filePath = (isAsset && !isDir)
                 ? root + this.path
                 : path.join(root,this.path,'index.html');
-
+            if(isAsset && isDir && this.path !== '/' && !/\/$/.test(this.path))
+                this.redirect(root + this.path + '/');
             debug('served:', filePath);
             yield send(this, filePath);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-serve",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Koa middleware for serving static files",
   "main": "index.js",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -50,7 +50,7 @@ describe('serve()', function() {
 
     request(app.listen())
     .get('/fixtures')
-    .expect(200)
+    .expect(302)
     .expect('index\n', done);
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,15 @@ describe('serve()', function() {
     .expect('index\n', done);
   });
 
+  it('should return index.html when requesting a directory without a slash-ending', function(done) {
+    app.use(serve('fixtures', __dirname));
+
+    request(app.listen())
+    .get('/fixtures')
+    .expect(200)
+    .expect('index\n', done);
+  });
+
   it('should yield the control when not GET', function(done) {
     app.use(serve('fixtures', __dirname));
 


### PR DESCRIPTION
I use DEBUG to show the `koa-serve` debug info : `DEBUG=koa-serve node index.js`

And I saw following debug info and I've fixed it in the [source code](https://github.com/adamkdean/koa-serve/blob/master/index.js#L28)

```
GET /game_1049911 - 2
  koa-serve requested: +8s /game_1049911
  koa-serve served: +1ms /home/jun1st/yongdudehekou/game_1049911index.html
```

Meanwhile I used Assert to pass all tests including the extra one added and bump the version to v0.1.8
